### PR TITLE
feat(idea-auditor): v0.5.0 — MCP tools complete, analytics-bridge scaffold, E2E expansion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -181,7 +181,7 @@
     {
       "name": "idea-auditor",
       "description": "Evidence-driven scorecard engine for ideas, MVPs, and evolving projects. Scores across 5 dimensions (wedge, friction, loop, timing, trust) using scientific frameworks (JTBD, TAM, ISO, Rogers, Mayer) with confidence-weighted scoring and PROCEED/ITERATE/KILL gates.",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Nuno Salvacao",
         "email": "nuno.salvacao@gmail.com"

--- a/plugins/idea-auditor/.claude-plugin/plugin.json
+++ b/plugins/idea-auditor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-auditor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Evidence-driven scorecard engine for ideas, MVPs, and evolving projects. Uses scientific frameworks (JTBD, TAM, ISO, Rogers, Mayer) as anchors and mathematical proxies as instrumentation. Scores ideas across 5 dimensions (wedge, friction, loop, timing, trust) with a confidence-weighted model and gates (PROCEED / ITERATE / KILL).",
   "author": {
     "name": "Nuno Salvacao",

--- a/plugins/idea-auditor/.mcp.json
+++ b/plugins/idea-auditor/.mcp.json
@@ -9,6 +9,18 @@
         "GITHUB_TOKEN": "${GITHUB_TOKEN}"
       },
       "description": "Fetches external evidence signals (GitHub stats, registry downloads, trends, competitors) and normalizes them to evidence.schema.json for the idea-auditor scoring pipeline."
+    },
+    "idea-auditor-analytics-bridge": {
+      "command": "python",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/mcp/servers/analytics-bridge/server.py"
+      ],
+      "env": {
+        "ANALYTICS_PROVIDER": "${ANALYTICS_PROVIDER}",
+        "ANALYTICS_API_KEY": "${ANALYTICS_API_KEY}",
+        "ANALYTICS_PROJECT": "${ANALYTICS_PROJECT}"
+      },
+      "description": "Bridges product analytics providers (PostHog, Mixpanel, Amplitude) to evidence.schema.json items for TTFV/activation/referral signals. Tools are stubs in v0.5.0 — full implementation in v0.6.0."
     }
   }
 }

--- a/plugins/idea-auditor/README.md
+++ b/plugins/idea-auditor/README.md
@@ -97,12 +97,13 @@ Infra_Fork_Standard  # Infrastructure forks, standards, migrations (adds migrati
 /plugin install idea-auditor@nsalvacao-claude-code-plugins
 ```
 
-## Known Limitations (v0.4.0)
+## Known Limitations (v0.5.0)
 
 - **score_bruto is qualitative** — `calc_scorecard.py` computes deterministically but `score_bruto` (0–5) must be supplied via `--scores`. Specialist agents assist with dimension assessment but `score_bruto` still requires human judgment.
 - **Blockers and next_tests not script-populated** — `scorecard.json` outputs `blockers: []` and `next_tests: []`. `build_report.py` derives blockers from lowest `score_efetivo` and `needs_experiment=True`.
 - **Watch mode records writes only** — `hooks/scripts/snapshot.sh` snapshots file content after Write/Edit tool calls only. Deletions, git commits, and external edits are not captured.
-- **MCP server tools are mostly stubs** — `evidence-harvester` has `github_repo_stats` functional; `registry_downloads`, `trend_snapshot`, and `competitor_scan` are stubs planned for v0.5.0.
+- **MCP analytics-bridge is stub** — `analytics-bridge` tools (`fetch_events`, `fetch_funnels`, `fetch_referrals`) are stubs planned for v0.6.0. Use analytics provider UI or export data to STATE/ manually.
+- **trend_snapshot — Google Trends not implemented** — `evidence-harvester` scrapes GitHub Trending (weekly) but Google Trends has no stable public API without auth. Check trends.google.com manually.
 - **competitor-mapper produces no score_bruto** — It feeds wedge/friction/timing agents; it does not produce a dimension score for `calc_scorecard.py` directly.
 - **normalize_interviews.py — source is null when not found** — If interview notes have no `Interviewee:` / `Name:` / `Role:` metadata, `source` is left `null`. Use `--validate` to catch missing required fields before feeding into `grade_evidence.py`.
 

--- a/plugins/idea-auditor/mcp/servers/analytics-bridge/pyproject.toml
+++ b/plugins/idea-auditor/mcp/servers/analytics-bridge/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "idea-auditor-analytics-bridge"
+version = "0.5.0"
+description = "MCP server for idea-auditor: bridges product analytics providers (PostHog, Mixpanel, Amplitude) to evidence.schema.json items for TTFV/activation/referral signals."
+requires-python = ">=3.11"
+dependencies = [
+    "mcp>=1.0.0",
+    "httpx>=0.27.0",
+]
+
+[project.scripts]
+analytics-bridge = "server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/plugins/idea-auditor/mcp/servers/analytics-bridge/pyproject.toml
+++ b/plugins/idea-auditor/mcp/servers/analytics-bridge/pyproject.toml
@@ -8,12 +8,11 @@ dependencies = [
     "httpx>=0.27.0",
 ]
 
+py_modules = ["server"]
+
 [project.scripts]
 analytics-bridge = "server:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["."]

--- a/plugins/idea-auditor/mcp/servers/analytics-bridge/server.py
+++ b/plugins/idea-auditor/mcp/servers/analytics-bridge/server.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""analytics-bridge MCP server — idea-auditor v0.5.0
+
+Bridges product analytics providers (PostHog, Mixpanel, Amplitude) to
+evidence.schema.json items. Surfaces TTFV/activation/referral signals as
+evidence for the friction and loop dimensions.
+
+Tools:
+  fetch_events    — fetch product events from analytics provider (stub — v0.6.0)
+  fetch_funnels   — fetch activation funnel (TTFV proxy) from analytics provider (stub — v0.6.0)
+  fetch_referrals — fetch referral loop metrics (K-factor inputs) (stub — v0.6.0)
+
+Environment:
+  ANALYTICS_PROVIDER  — posthog | mixpanel | amplitude (default: posthog)
+  ANALYTICS_API_KEY   — provider API key
+  ANALYTICS_PROJECT   — project ID / token
+
+All tools are stubs in v0.5.0. Full implementation planned for v0.6.0.
+"""
+
+import asyncio
+import json
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
+# ---------------------------------------------------------------------------
+# MCP server instance
+# ---------------------------------------------------------------------------
+app = Server("idea-auditor-analytics-bridge")
+
+# ---------------------------------------------------------------------------
+# Tool stubs
+# ---------------------------------------------------------------------------
+
+_STUB_NOTE = (
+    "Full implementation planned for v0.6.0. "
+    "To use now: query your analytics provider directly and load results as "
+    "evidence items in STATE/ (format: evidence.schema.json)."
+)
+
+
+def _stub_result(tool: str, extra: dict | None = None) -> dict:
+    result = {
+        "status": "stub",
+        "tool": tool,
+        "planned_version": "v0.6.0",
+        "message": _STUB_NOTE,
+    }
+    if extra:
+        result.update(extra)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# MCP tool definitions
+# ---------------------------------------------------------------------------
+
+@app.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="fetch_events",
+            description=(
+                "[STUB — v0.6.0] Fetch product events from PostHog, Mixpanel, or Amplitude. "
+                "Will return event counts normalized to evidence.schema.json items "
+                "(quality_tier: behavioral, dimension: friction or loop). "
+                "Requires ANALYTICS_PROVIDER and ANALYTICS_API_KEY env vars."
+            ),
+            inputSchema={
+                "type": "object",
+                "required": ["event_name"],
+                "properties": {
+                    "event_name": {
+                        "type": "string",
+                        "description": "Event name to fetch (e.g. 'user_activated', 'feature_used')",
+                    },
+                    "days": {
+                        "type": "integer",
+                        "description": "Lookback window in days (default: 30)",
+                        "default": 30,
+                    },
+                    "dimension": {
+                        "type": "string",
+                        "enum": ["wedge", "friction", "loop", "timing", "trust", "migration"],
+                        "description": "Evidence dimension this event maps to",
+                    },
+                },
+            },
+        ),
+        types.Tool(
+            name="fetch_funnels",
+            description=(
+                "[STUB — v0.6.0] Fetch activation funnel steps from analytics provider. "
+                "Will return TTFV (time-to-first-value) and activation rate as evidence items "
+                "(quality_tier: behavioral, dimension: friction). "
+                "Requires ANALYTICS_PROVIDER and ANALYTICS_API_KEY env vars."
+            ),
+            inputSchema={
+                "type": "object",
+                "required": ["funnel_id"],
+                "properties": {
+                    "funnel_id": {
+                        "type": "string",
+                        "description": "Funnel identifier in the analytics provider",
+                    },
+                    "days": {
+                        "type": "integer",
+                        "description": "Lookback window in days (default: 30)",
+                        "default": 30,
+                    },
+                },
+            },
+        ),
+        types.Tool(
+            name="fetch_referrals",
+            description=(
+                "[STUB — v0.6.0] Fetch referral loop metrics (K-factor inputs) from analytics provider. "
+                "Will return invites_per_user and referral_conversion_rate as evidence items "
+                "(quality_tier: behavioral, dimension: loop). "
+                "Requires ANALYTICS_PROVIDER and ANALYTICS_API_KEY env vars."
+            ),
+            inputSchema={
+                "type": "object",
+                "required": [],
+                "properties": {
+                    "days": {
+                        "type": "integer",
+                        "description": "Lookback window in days (default: 30)",
+                        "default": 30,
+                    },
+                },
+            },
+        ),
+    ]
+
+
+@app.call_tool()
+async def call_tool(
+    name: str, arguments: dict
+) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
+
+    if name == "fetch_events":
+        result = _stub_result("fetch_events", {"event_name": arguments.get("event_name")})
+    elif name == "fetch_funnels":
+        result = _stub_result("fetch_funnels", {"funnel_id": arguments.get("funnel_id")})
+    elif name == "fetch_referrals":
+        result = _stub_result("fetch_referrals")
+    else:
+        result = {"error": f"Unknown tool: {name}"}
+
+    return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+async def _main() -> None:
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        await app.run(
+            read_stream,
+            write_stream,
+            InitializationOptions(
+                server_name="idea-auditor-analytics-bridge",
+                server_version="0.5.0",
+                capabilities=app.get_capabilities(
+                    notification_options=NotificationOptions(),
+                    experimental_capabilities={},
+                ),
+            ),
+        )
+
+
+def main() -> None:
+    asyncio.run(_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/idea-auditor/mcp/servers/evidence-harvester/pyproject.toml
+++ b/plugins/idea-auditor/mcp/servers/evidence-harvester/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idea-auditor-evidence-harvester"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server for idea-auditor: fetches external evidence signals (GitHub stats, registry downloads, trends, competitor scan) and normalizes them to evidence.schema.json."
 requires-python = ">=3.11"
 dependencies = [

--- a/plugins/idea-auditor/mcp/servers/evidence-harvester/pyproject.toml
+++ b/plugins/idea-auditor/mcp/servers/evidence-harvester/pyproject.toml
@@ -8,12 +8,11 @@ dependencies = [
     "httpx>=0.27.0",
 ]
 
+py_modules = ["server"]
+
 [project.scripts]
 evidence-harvester = "server:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["."]

--- a/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
+++ b/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""evidence-harvester MCP server — idea-auditor v0.4.0
+"""evidence-harvester MCP server — idea-auditor v0.5.0
 
 Fetches external evidence signals and normalizes them to evidence.schema.json format.
 
 Tools:
   github_repo_stats   — GitHub star/fork/contributor velocity, security posture
-  registry_downloads  — npm/pypi/homebrew weekly download counts (stub — v0.5.0)
-  trend_snapshot      — GitHub trending & Google Trends signals (stub — v0.5.0)
-  competitor_scan     — competitor metric list normalized to same proxies (stub — v0.5.0)
+  registry_downloads  — npm/pypi/homebrew weekly download counts
+  trend_snapshot      — GitHub trending & Google Trends signals (stub — v0.6.0)
+  competitor_scan     — competitor metric list normalized to same proxies (stub — v0.6.0)
 
 Environment:
   GITHUB_TOKEN — optional; absent → rate-limited to 60 req/h
@@ -171,33 +171,79 @@ async def _fetch_github_repo_stats(client: httpx.AsyncClient, repo: str, state_d
 # Tool stubs (v0.5.0)
 # ---------------------------------------------------------------------------
 
-def _fetch_registry_downloads(package: str, registry: str, state_dir: str | None) -> dict:
-    """Stub — npm/pypi/homebrew registry downloads. Full implementation in v0.5.0."""
-    return {
-        "status": "stub",
-        "message": f"registry_downloads for {registry}/{package} is not yet implemented. "
-                   "Full implementation planned for v0.5.0.",
+async def _fetch_registry_downloads(client: httpx.AsyncClient, package: str, registry: str, state_dir: str | None) -> dict:
+    """Fetch weekly download counts from npm, pypi, or homebrew. Results cached daily."""
+    cache_key = f"registry_{registry}_{package}"
+    cached = _cache_load(cache_key, state_dir)
+    if cached:
+        return {**cached, "cache_hit": True}
+
+    result: dict = {
         "package": package,
         "registry": registry,
+        "fetched_at": TODAY,
+        "weekly_downloads": None,
+        "monthly_downloads": None,
     }
+
+    try:
+        if registry == "npm":
+            resp = await client.get(
+                f"https://api.npmjs.org/downloads/point/last-week/{package}", timeout=15
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            result["weekly_downloads"] = data.get("downloads")
+
+        elif registry == "pypi":
+            resp = await client.get(
+                f"https://pypistats.org/api/packages/{package}/recent", timeout=15
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            pkg_data = data.get("data") or {}
+            result["weekly_downloads"] = pkg_data.get("last_week")
+            result["monthly_downloads"] = pkg_data.get("last_month")
+
+        elif registry == "homebrew":
+            resp = await client.get(
+                f"https://formulae.brew.sh/api/formula/{package}.json", timeout=15
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            install_30d = (data.get("analytics") or {}).get("install", {}).get("30d", {})
+            monthly = sum(install_30d.values()) if install_30d else None
+            result["monthly_downloads"] = monthly
+            result["weekly_downloads"] = round(monthly / 4) if monthly else None
+
+        else:
+            return {"error": f"Unknown registry: {registry}", "package": package, "registry": registry}
+
+    except httpx.HTTPStatusError as e:
+        return {"error": f"HTTP {e.response.status_code}: {e.response.reason_phrase}", "package": package, "registry": registry}
+    except Exception as e:
+        return {"error": str(e), "package": package, "registry": registry}
+
+    _cache_save(cache_key, result, state_dir)
+    return result
 
 
 def _fetch_trend_snapshot(query: str, state_dir: str | None) -> dict:
-    """Stub — GitHub trending + Google Trends. Full implementation in v0.5.0."""
+    """Stub — GitHub trending + Google Trends. Full implementation in v0.6.0."""
     return {
         "status": "stub",
         "message": f"trend_snapshot for '{query}' is not yet implemented. "
-                   "Full implementation planned for v0.5.0.",
+                   "Full implementation planned for v0.6.0.",
         "query": query,
     }
 
 
 def _fetch_competitor_scan(alternatives: list[str], state_dir: str | None) -> dict:
-    """Stub — competitor metric scan normalized to same proxies. Full implementation in v0.5.0."""
+    """Stub — competitor metric scan normalized to same proxies. Full implementation in v0.6.0."""
     return {
         "status": "stub",
         "message": "competitor_scan is not yet implemented. Use competitor-mapper agent for now. "
-                   "Full implementation planned for v0.5.0.",
+                   "Full implementation planned for v0.6.0.",
         "alternatives": alternatives,
     }
 
@@ -245,27 +291,28 @@ async def list_tools() -> list[types.Tool]:
         types.Tool(
             name="registry_downloads",
             description=(
-                "[STUB — v0.5.0] Fetch weekly download counts from npm, pypi, or homebrew. "
-                "Returns a stub response indicating planned implementation."
+                "Fetch weekly download counts from npm, pypi, or homebrew for idea-auditor evidence. "
+                "Returns weekly_downloads (and monthly_downloads for pypi/homebrew). "
+                "Results are cached daily in STATE/.cache/evidence-harvester/."
             ),
             inputSchema={
                 "type": "object",
                 "required": ["package", "registry"],
                 "properties": {
-                    "package": {"type": "string", "description": "Package name"},
+                    "package": {"type": "string", "description": "Package name (e.g. 'httpx', 'react')"},
                     "registry": {
                         "type": "string",
                         "enum": ["npm", "pypi", "homebrew"],
                         "description": "Package registry",
                     },
-                    "state_dir": {"type": "string"},
+                    "state_dir": {"type": "string", "description": "Path to STATE/ directory for cache. Defaults to STATE/"},
                 },
             },
         ),
         types.Tool(
             name="trend_snapshot",
             description=(
-                "[STUB — v0.5.0] Snapshot GitHub trending and Google Trends signals for a query. "
+                "[STUB — v0.6.0] Snapshot GitHub trending and Google Trends signals for a query. "
                 "Returns a stub response indicating planned implementation."
             ),
             inputSchema={
@@ -280,7 +327,7 @@ async def list_tools() -> list[types.Tool]:
         types.Tool(
             name="competitor_scan",
             description=(
-                "[STUB — v0.5.0] Scan a list of competitor repos/packages and return normalized "
+                "[STUB — v0.6.0] Scan a list of competitor repos/packages and return normalized "
                 "proxy metrics for the competitor-mapper agent. "
                 "Returns a stub response; use competitor-mapper agent for current analysis."
             ),
@@ -365,7 +412,8 @@ async def call_tool(
         return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
     elif name == "registry_downloads":
-        result = _fetch_registry_downloads(arguments["package"], arguments["registry"], state_dir)
+        async with httpx.AsyncClient() as client:
+            result = await _fetch_registry_downloads(client, arguments["package"], arguments["registry"], state_dir)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "trend_snapshot":
@@ -391,7 +439,7 @@ async def _main() -> None:
             write_stream,
             InitializationOptions(
                 server_name="idea-auditor-evidence-harvester",
-                server_version="0.4.0",
+                server_version="0.5.0",
                 capabilities=app.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},

--- a/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
+++ b/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
@@ -67,10 +67,18 @@ def _cache_save(key: str, data: dict, state_dir: str | None = None) -> None:
 
 
 async def _github_get(client: "httpx.AsyncClient", path: str) -> dict | list | None:
-    """Async GitHub API GET via injected httpx.AsyncClient (non-blocking)."""
+    """Async GitHub API GET via injected httpx.AsyncClient (non-blocking).
+
+    Auth headers are set per-request so a single shared client can be used
+    across tool branches without leaking the GitHub token to third-party APIs.
+    """
     url = f"{GITHUB_API}{path}"
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     try:
-        resp = await client.get(url, timeout=15)
+        resp = await client.get(url, timeout=15, headers=headers)
         resp.raise_for_status()
         return resp.json()
     except httpx.HTTPStatusError as e:
@@ -271,7 +279,7 @@ async def _fetch_trend_snapshot(client: httpx.AsyncClient, query: str, state_dir
 
             # Description (first <p> tag content, stripped)
             desc_m = re.search(r'<p[^>]*>\s*(.*?)\s*</p>', article, re.DOTALL)
-            description = re.sub(r'<[^>]+>', '', desc_m.group(1)).strip() if desc_m else None
+            description = re.sub(r'<.*?>', '', desc_m.group(1), flags=re.DOTALL).strip() if desc_m else None
 
             # Relevance: does the query match repo name or description?
             searchable = (repo_name + " " + (description or "")).lower()
@@ -454,80 +462,75 @@ async def call_tool(
 
     state_dir = arguments.get("state_dir")
 
-    if name == "github_repo_stats":
-        repo = arguments["repo"]
-        dimension = arguments.get("dimension")
-        as_evidence = arguments.get("as_evidence", False)
+    # Single shared client for all branches — auth headers are set per-request
+    # inside _github_get so the token is never sent to third-party registries.
+    async with httpx.AsyncClient() as client:
+        if name == "github_repo_stats":
+            repo = arguments["repo"]
+            dimension = arguments.get("dimension")
+            as_evidence = arguments.get("as_evidence", False)
 
-        token = os.environ.get("GITHUB_TOKEN")
-        headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        async with httpx.AsyncClient(headers=headers) as client:
             data = await _fetch_github_repo_stats(client, repo, state_dir)
 
-        if "error" in data:
+            if "error" in data:
+                return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
+
+            if as_evidence:
+                items = []
+                # Stars as loop/timing signal
+                if data.get("stars") is not None:
+                    items.append(_to_evidence_item(
+                        claim=f"{repo} has {data['stars']} GitHub stars",
+                        source=f"github/{repo}",
+                        method="oss_metrics",
+                        collected_at=TODAY,
+                        quality_tier="proxy",
+                        dimension=dimension or "loop",
+                        raw={"stars": data["stars"], "forks": data["forks"]},
+                        normalized=f"stars={data['stars']}, forks={data['forks']}",
+                    ))
+                # Security posture as trust signal
+                if data.get("has_security_md") is not None:
+                    items.append(_to_evidence_item(
+                        claim=f"{repo} {'has' if data['has_security_md'] else 'does not have'} SECURITY.md",
+                        source=f"github/{repo}",
+                        method="oss_metrics",
+                        collected_at=TODAY,
+                        quality_tier="behavioral",
+                        dimension=dimension or "trust",
+                        raw={"has_security_md": data["has_security_md"]},
+                        normalized=f"has_security_md={data['has_security_md']}",
+                    ))
+                # Release freshness as timing signal
+                if data.get("last_release_days") is not None:
+                    items.append(_to_evidence_item(
+                        claim=f"{repo} last released {data['last_release_days']} days ago",
+                        source=f"github/{repo}",
+                        method="oss_metrics",
+                        collected_at=TODAY,
+                        quality_tier="proxy",
+                        dimension=dimension or "timing",
+                        raw={"last_release_date": data["last_release_date"], "last_release_days": data["last_release_days"]},
+                        normalized=f"last_release_days={data['last_release_days']}",
+                    ))
+                return [types.TextContent(type="text", text=json.dumps(items, indent=2))]
+
             return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
 
-        if as_evidence:
-            items = []
-            # Stars as loop/timing signal
-            if data.get("stars") is not None:
-                items.append(_to_evidence_item(
-                    claim=f"{repo} has {data['stars']} GitHub stars",
-                    source=f"github/{repo}",
-                    method="oss_metrics",
-                    collected_at=TODAY,
-                    quality_tier="proxy",
-                    dimension=dimension or "loop",
-                    raw={"stars": data["stars"], "forks": data["forks"]},
-                    normalized=f"stars={data['stars']}, forks={data['forks']}",
-                ))
-            # Security posture as trust signal
-            if data.get("has_security_md") is not None:
-                items.append(_to_evidence_item(
-                    claim=f"{repo} {'has' if data['has_security_md'] else 'does not have'} SECURITY.md",
-                    source=f"github/{repo}",
-                    method="oss_metrics",
-                    collected_at=TODAY,
-                    quality_tier="behavioral",
-                    dimension=dimension or "trust",
-                    raw={"has_security_md": data["has_security_md"]},
-                    normalized=f"has_security_md={data['has_security_md']}",
-                ))
-            # Release freshness as timing signal
-            if data.get("last_release_days") is not None:
-                items.append(_to_evidence_item(
-                    claim=f"{repo} last released {data['last_release_days']} days ago",
-                    source=f"github/{repo}",
-                    method="oss_metrics",
-                    collected_at=TODAY,
-                    quality_tier="proxy",
-                    dimension=dimension or "timing",
-                    raw={"last_release_date": data["last_release_date"], "last_release_days": data["last_release_days"]},
-                    normalized=f"last_release_days={data['last_release_days']}",
-                ))
-            return [types.TextContent(type="text", text=json.dumps(items, indent=2))]
-
-        return [types.TextContent(type="text", text=json.dumps(data, indent=2))]
-
-    elif name == "registry_downloads":
-        async with httpx.AsyncClient() as client:
+        elif name == "registry_downloads":
             result = await _fetch_registry_downloads(client, arguments["package"], arguments["registry"], state_dir)
-        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
-    elif name == "trend_snapshot":
-        async with httpx.AsyncClient() as client:
+        elif name == "trend_snapshot":
             result = await _fetch_trend_snapshot(client, arguments["query"], state_dir)
-        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
-    elif name == "competitor_scan":
-        async with httpx.AsyncClient() as client:
+        elif name == "competitor_scan":
             result = await _fetch_competitor_scan(client, arguments.get("alternatives", []), state_dir)
-        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
-    else:
-        return [types.TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]
+        else:
+            return [types.TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
+++ b/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
@@ -228,14 +228,81 @@ async def _fetch_registry_downloads(client: httpx.AsyncClient, package: str, reg
     return result
 
 
-def _fetch_trend_snapshot(query: str, state_dir: str | None) -> dict:
-    """Stub — GitHub trending + Google Trends. Full implementation in v0.6.0."""
-    return {
-        "status": "stub",
-        "message": f"trend_snapshot for '{query}' is not yet implemented. "
-                   "Full implementation planned for v0.6.0.",
+async def _fetch_trend_snapshot(client: httpx.AsyncClient, query: str, state_dir: str | None) -> dict:
+    """Fetch GitHub Trending repos (weekly) matching the query. Google Trends not implemented.
+
+    Google Trends has no stable public API without auth or fragile third-party libraries
+    (pytrends regularly breaks due to Google blocking). Use trends.google.com manually.
+    """
+    cache_key = f"trend_{query.replace(' ', '_')}"
+    cached = _cache_load(cache_key, state_dir)
+    if cached:
+        return {**cached, "cache_hit": True}
+
+    trending_repos: list[dict] = []
+    github_error: str | None = None
+
+    try:
+        resp = await client.get(
+            "https://github.com/trending",
+            params={"since": "weekly"},
+            headers={"Accept": "text/html", "User-Agent": "idea-auditor/0.5.0"},
+            timeout=20,
+        )
+        resp.raise_for_status()
+        html = resp.text
+
+        # Extract article blocks (each article = one trending repo)
+        articles = re.findall(r'<article[^>]*Box-row[^>]*>(.*?)</article>', html, re.DOTALL)
+
+        query_words = {w.lower() for w in query.split() if len(w) > 2}
+
+        for article in articles[:25]:
+            # Repo path: first href matching owner/name pattern inside the article
+            repo_m = re.search(r'href="/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"', article)
+            if not repo_m:
+                continue
+            repo_name = repo_m.group(1)
+
+            # Stars this week
+            stars_m = re.search(r'([\d,]+)\s+stars?\s+this\s+week', article, re.IGNORECASE)
+            stars_week = int(stars_m.group(1).replace(",", "")) if stars_m else None
+
+            # Description (first <p> tag content, stripped)
+            desc_m = re.search(r'<p[^>]*>\s*(.*?)\s*</p>', article, re.DOTALL)
+            description = re.sub(r'<[^>]+>', '', desc_m.group(1)).strip() if desc_m else None
+
+            # Relevance: does the query match repo name or description?
+            searchable = (repo_name + " " + (description or "")).lower()
+            relevance = "match" if query_words and query_words.intersection(searchable.split()) else "trending"
+
+            trending_repos.append({
+                "repo": repo_name,
+                "stars_this_week": stars_week,
+                "description": description,
+                "relevance": relevance,
+            })
+
+    except httpx.HTTPStatusError as e:
+        github_error = f"HTTP {e.response.status_code}: {e.response.reason_phrase}"
+    except Exception as e:
+        github_error = str(e)
+
+    result = {
         "query": query,
+        "fetched_at": TODAY,
+        "github_trending_weekly": trending_repos if not github_error else None,
+        "github_error": github_error,
+        "google_trends": None,
+        "google_trends_note": (
+            "Google Trends has no stable public API without auth. "
+            "Check trends.google.com manually for keyword interest signals."
+        ),
     }
+
+    if not github_error:
+        _cache_save(cache_key, result, state_dir)
+    return result
 
 
 def _fetch_competitor_scan(alternatives: list[str], state_dir: str | None) -> dict:
@@ -312,15 +379,17 @@ async def list_tools() -> list[types.Tool]:
         types.Tool(
             name="trend_snapshot",
             description=(
-                "[STUB — v0.6.0] Snapshot GitHub trending and Google Trends signals for a query. "
-                "Returns a stub response indicating planned implementation."
+                "Snapshot GitHub Trending repos (weekly) matching a query. "
+                "Returns up to 25 trending repos with stars_this_week and relevance flag. "
+                "Google Trends not implemented (no stable public API without auth). "
+                "Results are cached daily in STATE/.cache/evidence-harvester/."
             ),
             inputSchema={
                 "type": "object",
                 "required": ["query"],
                 "properties": {
-                    "query": {"type": "string", "description": "Search query (e.g. 'AI code review')"},
-                    "state_dir": {"type": "string"},
+                    "query": {"type": "string", "description": "Search query to match against trending repos (e.g. 'AI code review')"},
+                    "state_dir": {"type": "string", "description": "Path to STATE/ directory for cache. Defaults to STATE/"},
                 },
             },
         ),
@@ -417,7 +486,8 @@ async def call_tool(
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "trend_snapshot":
-        result = _fetch_trend_snapshot(arguments["query"], state_dir)
+        async with httpx.AsyncClient() as client:
+            result = await _fetch_trend_snapshot(client, arguments["query"], state_dir)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "competitor_scan":

--- a/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
+++ b/plugins/idea-auditor/mcp/servers/evidence-harvester/server.py
@@ -19,6 +19,7 @@ Cache:
 import asyncio
 import json
 import os
+import re
 from datetime import date, datetime, timezone
 from pathlib import Path
 
@@ -305,14 +306,42 @@ async def _fetch_trend_snapshot(client: httpx.AsyncClient, query: str, state_dir
     return result
 
 
-def _fetch_competitor_scan(alternatives: list[str], state_dir: str | None) -> dict:
-    """Stub — competitor metric scan normalized to same proxies. Full implementation in v0.6.0."""
-    return {
-        "status": "stub",
-        "message": "competitor_scan is not yet implemented. Use competitor-mapper agent for now. "
-                   "Full implementation planned for v0.6.0.",
-        "alternatives": alternatives,
-    }
+async def _fetch_competitor_scan(client: httpx.AsyncClient, alternatives: list[str], state_dir: str | None) -> list[dict]:
+    """Scan a list of GitHub repos or packages and return normalized competitor proxy matrix.
+
+    For each alternative: fetches GitHub stats and maps to the 7 proxy fields used by
+    the competitor-mapper agent. pricing_floor_usd and jtbd_match_score are left null —
+    they require human research and cannot be inferred.
+    """
+    results = []
+    for alt in alternatives:
+        entry: dict = {
+            "alternative": alt,
+            "stars_or_installs": None,
+            "weekly_downloads": None,
+            "github_contributors": None,
+            "last_release_days": None,
+            "pricing_floor_usd": None,     # requires human research
+            "integration_depth": None,     # requires human research
+            "jtbd_match_score": None,      # requires human research
+            "error": None,
+        }
+
+        # Treat as GitHub repo if it matches owner/name pattern
+        if re.match(r'^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$', alt):
+            data = await _fetch_github_repo_stats(client, alt, state_dir)
+            if "error" in data:
+                entry["error"] = data["error"]
+            else:
+                entry["stars_or_installs"] = data.get("stars")
+                entry["github_contributors"] = data.get("active_contributors_90d")
+                entry["last_release_days"] = data.get("last_release_days")
+        else:
+            entry["error"] = f"'{alt}' does not match owner/name format — package registry lookup not implemented here; use registry_downloads tool"
+
+        results.append(entry)
+
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -396,9 +425,11 @@ async def list_tools() -> list[types.Tool]:
         types.Tool(
             name="competitor_scan",
             description=(
-                "[STUB — v0.6.0] Scan a list of competitor repos/packages and return normalized "
-                "proxy metrics for the competitor-mapper agent. "
-                "Returns a stub response; use competitor-mapper agent for current analysis."
+                "Scan a list of GitHub repos and return a normalized competitor proxy matrix "
+                "for the competitor-mapper agent. For each alternative: fetches GitHub stars, "
+                "active contributors (90d), last release age. pricing_floor_usd, "
+                "integration_depth, and jtbd_match_score are left null (require human research). "
+                "Reuses github_repo_stats cache."
             ),
             inputSchema={
                 "type": "object",
@@ -491,7 +522,8 @@ async def call_tool(
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "competitor_scan":
-        result = _fetch_competitor_scan(arguments.get("alternatives", []), state_dir)
+        async with httpx.AsyncClient() as client:
+            result = await _fetch_competitor_scan(client, arguments.get("alternatives", []), state_dir)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     else:

--- a/plugins/idea-auditor/skills/watch/SKILL.md
+++ b/plugins/idea-auditor/skills/watch/SKILL.md
@@ -59,13 +59,13 @@ Use `diff_scorecards.py` to compare any two scorecards — including those produ
 ```bash
 # Compare yesterday's scorecard with today's
 python3 scripts/diff_scorecards.py \
-  --before STATE/scorecard_20260408.json \
-  --after  STATE/scorecard_20260409.json
+  --before REPORTS/scorecard-20260408.json \
+  --after  REPORTS/scorecard-20260409.json
 
 # Output as JSON for automated pipelines
 python3 scripts/diff_scorecards.py \
-  --before STATE/scorecard_v1.json \
-  --after  STATE/scorecard_v2.json \
+  --before REPORTS/scorecard-v1.json \
+  --after  REPORTS/scorecard-v2.json \
   --format json
 ```
 
@@ -73,7 +73,7 @@ python3 scripts/diff_scorecards.py \
 
 ### Typical Regression Workflow
 
-1. Save a baseline: `cp STATE/scorecard.json STATE/scorecard_baseline.json`
+1. Save a baseline: `cp REPORTS/scorecard-YYYYMMDD.json REPORTS/scorecard-baseline.json`
 2. Make changes to IDEA.md or evidence files
 3. Re-score: `/idea-auditor:score`
 4. Diff: `python3 scripts/diff_scorecards.py --before STATE/scorecard_baseline.json --after STATE/scorecard.json`

--- a/plugins/idea-auditor/tests/run_e2e_tests.sh
+++ b/plugins/idea-auditor/tests/run_e2e_tests.sh
@@ -365,6 +365,11 @@ print('found='+str(len(fns)))
 \"" \
     "found=1"
 
+assert_output_contains \
+    "S7: _fetch_competitor_scan is async with client param" \
+    "python3 -c \"import ast; tree=ast.parse(open('$SERVER_PY').read()); fns=[n for n in ast.walk(tree) if isinstance(n,ast.AsyncFunctionDef) and n.name=='_fetch_competitor_scan']; f=fns[0] if fns else None; print('async='+str(bool(fns))+' client='+str(any(a.arg=='client' for a in (f.args.args if f else []))))\"" \
+    "async=True client=True"
+
 # ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------

--- a/plugins/idea-auditor/tests/run_e2e_tests.sh
+++ b/plugins/idea-auditor/tests/run_e2e_tests.sh
@@ -355,7 +355,7 @@ assert_output_contains \
     "async=True client=True"
 
 assert_output_contains \
-    "S7: trend_snapshot result has github_trending_weekly key" \
+    "S7: _fetch_trend_snapshot function exists" \
     "python3 -c \"
 import ast, types as _t
 src = open('$SERVER_PY').read()

--- a/plugins/idea-auditor/tests/run_e2e_tests.sh
+++ b/plugins/idea-auditor/tests/run_e2e_tests.sh
@@ -340,6 +340,32 @@ assert_output_contains \
     "commitment"
 
 # ---------------------------------------------------------------------------
+# Scenario 7 — evidence-harvester server.py structural checks (no network)
+# ---------------------------------------------------------------------------
+
+SERVER_PY="mcp/servers/evidence-harvester/server.py"
+
+assert_exit \
+    "S7: server.py is valid Python AST" \
+    "python3 -c \"import ast; ast.parse(open('$SERVER_PY').read())\""
+
+assert_output_contains \
+    "S7: _fetch_trend_snapshot is async with client param" \
+    "python3 -c \"import ast, sys; tree=ast.parse(open('$SERVER_PY').read()); fns=[n for n in ast.walk(tree) if isinstance(n,ast.AsyncFunctionDef) and n.name=='_fetch_trend_snapshot']; f=fns[0] if fns else None; print('async='+str(bool(fns))+' client='+str(any(a.arg=='client' for a in (f.args.args if f else [])))+'')\"" \
+    "async=True client=True"
+
+assert_output_contains \
+    "S7: trend_snapshot result has github_trending_weekly key" \
+    "python3 -c \"
+import ast, types as _t
+src = open('$SERVER_PY').read()
+tree = ast.parse(src)
+fns = [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef,ast.AsyncFunctionDef)) and n.name=='_fetch_trend_snapshot']
+print('found='+str(len(fns)))
+\"" \
+    "found=1"
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 

--- a/plugins/idea-auditor/tests/run_e2e_tests.sh
+++ b/plugins/idea-auditor/tests/run_e2e_tests.sh
@@ -370,6 +370,26 @@ assert_output_contains \
     "python3 -c \"import ast; tree=ast.parse(open('$SERVER_PY').read()); fns=[n for n in ast.walk(tree) if isinstance(n,ast.AsyncFunctionDef) and n.name=='_fetch_competitor_scan']; f=fns[0] if fns else None; print('async='+str(bool(fns))+' client='+str(any(a.arg=='client' for a in (f.args.args if f else []))))\"" \
     "async=True client=True"
 
+BRIDGE_SERVER="mcp/servers/analytics-bridge/server.py"
+
+assert_exit \
+    "S7: analytics-bridge server.py exists" \
+    "test -f '$BRIDGE_SERVER'"
+
+assert_exit \
+    "S7: analytics-bridge server.py is valid Python AST" \
+    "python3 -c \"import ast; ast.parse(open('$BRIDGE_SERVER').read())\""
+
+assert_output_contains \
+    "S7: analytics-bridge declares fetch_events tool" \
+    "python3 -c \"
+import ast
+tree = ast.parse(open('$BRIDGE_SERVER').read())
+strings = [n.value for n in ast.walk(tree) if isinstance(n, ast.Constant) and isinstance(n.value, str)]
+print('fetch_events' in strings)
+\"" \
+    "True"
+
 # ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------

--- a/plugins/idea-auditor/tests/run_e2e_tests.sh
+++ b/plugins/idea-auditor/tests/run_e2e_tests.sh
@@ -391,6 +391,57 @@ print('fetch_events' in strings)
     "True"
 
 # ---------------------------------------------------------------------------
+# Scenario 8 — normalize_interviews.py --validate rejects null source
+# ---------------------------------------------------------------------------
+
+NO_SOURCE_MD="$_TMP_DIR/no_source.md"
+cat > "$NO_SOURCE_MD" <<'NOSRCEOF'
+## Interview 1
+Date: 2026-04-09
+Dimension: wedge
+Pain: I waste hours on manual research every week.
+Severity: 4/5
+Frequency: weekly
+NOSRCEOF
+
+assert_exit \
+    "S8: --validate exits 1 when source is null (no interviewee metadata)" \
+    "python3 scripts/normalize_interviews.py --input '$NO_SOURCE_MD' --validate" \
+    1
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — grade_evidence.py handles confidence_components: {} without crash
+# ---------------------------------------------------------------------------
+
+EMPTY_CC_EVIDENCE="$_TMP_DIR/empty_cc.json"
+cat > "$EMPTY_CC_EVIDENCE" <<'CCEOF'
+[
+  {
+    "claim": "User spends 3h/week on manual validation",
+    "source": "Alice, Senior Engineer",
+    "method": "interview",
+    "collected_at": "2026-04-01",
+    "quality_tier": "stated",
+    "dimension": "wedge",
+    "raw": null,
+    "normalized": null,
+    "confidence_components": {}
+  }
+]
+CCEOF
+
+GRADED_CC_OUT="$_TMP_DIR/graded_cc.json"
+
+assert_exit \
+    "S9: grade_evidence.py exits 0 with confidence_components: {}" \
+    "python3 scripts/grade_evidence.py --evidence '$EMPTY_CC_EVIDENCE' --out '$GRADED_CC_OUT'"
+
+assert_output_contains \
+    "S9: graded output contains conf_dim (no crash on empty confidence_components)" \
+    "python3 -c \"import json; d=json.load(open('$GRADED_CC_OUT')); print(str(d))\"" \
+    "conf_dim"
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Completes the `idea-auditor` v0.5.0 milestone — 5 tasks (IDEA-027 → IDEA-031).

### What's new

**IDEA-027 — registry_downloads functional (npm / pypi / homebrew)**
- Replaces stub with async httpx implementation
- npm: `api.npmjs.org/downloads/point/last-week/<package>`
- pypi: `pypistats.org/api/packages/<package>/recent` (last_week + last_month)
- homebrew: `formulae.brew.sh/api/formula/<name>.json` (install.30d sum; weekly ≈ monthly/4)
- Daily cache in `STATE/.cache/evidence-harvester/`; graceful error on HTTP failure

**IDEA-028 — trend_snapshot functional (GitHub Trending weekly)**
- Scrapes `github.com/trending?since=weekly` via httpx + regex (no bs4 dependency)
- Returns up to 25 repos with `stars_this_week`, `description`, `relevance` flag
- Relevance: "match" when query words appear in repo name or description
- Google Trends: `null` with explanatory note (no stable public API without auth/pytrends fragility)
- Daily cache; graceful degradation on scraping failure

**IDEA-029 — competitor_scan functional (GitHub proxy matrix)**
- Accepts list of `owner/name` GitHub alternatives
- Per entry: fetches github_repo_stats (reuses daily cache)
- Maps to 7 competitor-mapper proxies: stars_or_installs, github_contributors, last_release_days (from GitHub); pricing_floor_usd, integration_depth, jtbd_match_score left `null` (require human research)
- Non-owner/name entries: clear error message, no crash

**IDEA-030 — analytics-bridge MCP server scaffold**
- `mcp/servers/analytics-bridge/server.py`: 3 tool stubs (fetch_events, fetch_funnels, fetch_referrals) targeting PostHog/Mixpanel/Amplitude; planned for v0.6.0
- `pyproject.toml`: mcp>=1.0.0, httpx>=0.27.0
- `.mcp.json` updated with analytics-bridge entry (ANALYTICS_PROVIDER, ANALYTICS_API_KEY, ANALYTICS_PROJECT)

**IDEA-031 — E2E expansion + v0.5.0 versioning**
- S7 structural tests: AST validity + async/client signature checks for all 3 new functions + analytics-bridge existence and tool declaration
- S8: `normalize_interviews.py --validate` exits 1 when source is null
- S9: `grade_evidence.py` processes `confidence_components: {}` without crash
- plugin.json + marketplace.json: 0.4.0 → 0.5.0
- README Known Limitations updated for v0.5.0

## Test plan

- [x] `bash plugins/idea-auditor/tests/run_e2e_tests.sh --verbose` → 29 passed, 0 failed
- [x] `bash plugins/idea-auditor/tests/run_golden_tests.sh` → 2 passed
- [x] `bash plugins/idea-auditor/tests/schema_contract_tests.sh` → 12 passed
- [x] `python3 -c "import json; json.load(open('plugins/idea-auditor/.mcp.json'))"` → OK
- [x] `python3 -c "import json; json.load(open('plugins/idea-auditor/.claude-plugin/plugin.json'))"` → OK
- [ ] CI passes (plugin-validation.yml)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)