### PR TITLE
fix(ci): unblock docs-sync and release-please from CodeQL gate

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -44,12 +45,32 @@ jobs:
           AI_ENHANCE_DOCS: ${{ github.event.inputs.ai_enhance || 'false' }}
         run: python3 scripts/sync-docs.py
 
-      - name: Commit updated docs
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "docs(auto): sync plugin inventory and README table [skip ci]"
-          file_pattern: |
-            README.md
-            docs/plugins-inventory.md
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet -- README.md docs/plugins-inventory.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No docs changes detected — skipping PR."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Docs changes detected."
+          fi
+
+      - name: Open PR for docs update
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chore/docs-sync-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add README.md docs/plugins-inventory.md
+          git commit -m "docs(auto): sync plugin inventory and README table"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "docs(auto): sync plugin inventory and README table" \
+            --body "Automated docs sync triggered by push to \`main\`. Only markdown files changed — CodeQL will pass." \
+            --base main \
+            --head "$BRANCH"
+          gh pr merge "$BRANCH" --auto --squash --delete-branch

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -61,16 +61,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="chore/docs-sync-${{ github.run_id }}"
+          BRANCH="chore/docs-sync-${{ github.run_id }}-${{ github.run_attempt }}"
+          PR_TITLE="docs(auto): sync plugin inventory and README table"
+          PR_BODY="Automated docs sync triggered by push to \`main\`. Only markdown files changed — CodeQL will pass."
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add README.md docs/plugins-inventory.md
           git commit -m "docs(auto): sync plugin inventory and README table"
           git push origin "$BRANCH"
-          gh pr create \
-            --title "docs(auto): sync plugin inventory and README table" \
-            --body "Automated docs sync triggered by push to \`main\`. Only markdown files changed — CodeQL will pass." \
-            --base main \
-            --head "$BRANCH"
-          gh pr merge "$BRANCH" --auto --squash --delete-branch
+          if PR_NUMBER="$(gh pr view "$BRANCH" --json number --jq '.number' 2>/dev/null)"; then
+            echo "PR already exists: #$PR_NUMBER — reusing."
+          else
+            gh pr create \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY" \
+              --base main \
+              --head "$BRANCH"
+            PR_NUMBER="$(gh pr view "$BRANCH" --json number --jq '.number')"
+          fi
+          gh pr merge "$PR_NUMBER" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary

Two CI workflows were failing after every merge to `main` due to a branch protection ruleset that applied to ALL branches (`~ALL`) and required CodeQL results before any push — creating circular dependencies.

### Root causes

**Docs Sync** — `git-auto-commit-action` pushed directly to `main`. The CodeQL branch protection rule blocks the push until CodeQL has run on that commit, but CodeQL can only run after the push. Circular dependency, not solvable without changing the architecture.

**Release** — `release-please-action` updates `refs/heads/release-please--branches--main` (its internal tracking branch). The ruleset's `~ALL` condition applied CodeQL gate to ALL branches, including this release-please branch — making it impossible for release-please to function.

### Fixes applied

**Ruleset change** (applied directly via GitHub API):
- Removed `~ALL` from ruleset conditions — keeps only `~DEFAULT_BRANCH`
- The CodeQL gate now only applies to `main`, not to every branch in the repo
- Unblocks release-please from managing `refs/heads/release-please--branches--main`

**`docs-sync.yml` workflow change** (this PR):
- Replaced `git-auto-commit-action` direct push with a PR-based approach
- Workflow creates a short-lived branch `chore/docs-sync-<run_id>`, commits, opens a PR, and enables auto-merge
- CodeQL runs on the PR branch, then auto-merge completes when checks pass
- No infinite loop: trigger paths (`plugins/**`, `.claude-plugin/marketplace.json`, `scripts/sync-docs.py`) don't include `README.md` or `docs/` — merged commit won't re-trigger docs-sync

## Test plan

- [ ] Merge this PR and confirm CodeQL passes on the PR branch
- [ ] Trigger `workflow_dispatch` on Docs Sync and verify it creates a PR with auto-merge
- [ ] Trigger a push to main that touches `plugins/**` and verify the full cycle completes
- [ ] Verify Release workflow passes on the next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)